### PR TITLE
Mapper has been moved to Converter

### DIFF
--- a/src/AutoTuneLoaderPlugin.php
+++ b/src/AutoTuneLoaderPlugin.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace jæm3l\AutoTuneLoader;
 
-use Codesound\Mapper;
+use Codesound\Converter;
 use Codesound\Player;
 use Codesound\Sequence;
 use Codesound\SoundDumper;
@@ -50,7 +50,7 @@ class AutoTuneLoaderPlugin implements PluginInterface, EventSubscriberInterface
             $values[] = [$index, $length];
         }
 
-        $tuples = (new Mapper())->map($values);
+        $tuples = (new Converter())->convert($values);
         $sequence = Sequence::fromTuples($tuples);
         $player = new Player($sequence);
 


### PR DESCRIPTION
Mapper is marked as @deprecated since Version 1.1
Due to xosofox/codesound's Backward Compatibility Promise, this would still work, but to stay updated with upcoming versions, this change is necessary

:D :D :D